### PR TITLE
Add support for Nautilus over SMLHelper

### DIFF
--- a/CyclopsDockingMod.sln
+++ b/CyclopsDockingMod.sln
@@ -8,17 +8,23 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		DebugSML|Any CPU = DebugSML|Any CPU
 		DebugLegacy|Any CPU = DebugLegacy|Any CPU
 		Release|Any CPU = Release|Any CPU
+		ReleaseSML|Any CPU = ReleaseSML|Any CPU
 		ReleaseLegacy|Any CPU = ReleaseLegacy|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{98959DE3-D74C-4CDB-8583-A720BF07F997}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{98959DE3-D74C-4CDB-8583-A720BF07F997}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{98959DE3-D74C-4CDB-8583-A720BF07F997}.DebugSML|Any CPU.ActiveCfg = DebugSML|Any CPU
+		{98959DE3-D74C-4CDB-8583-A720BF07F997}.DebugSML|Any CPU.Build.0 = DebugSML|Any CPU
 		{98959DE3-D74C-4CDB-8583-A720BF07F997}.DebugLegacy|Any CPU.ActiveCfg = DebugLegacy|Any CPU
 		{98959DE3-D74C-4CDB-8583-A720BF07F997}.DebugLegacy|Any CPU.Build.0 = DebugLegacy|Any CPU
 		{98959DE3-D74C-4CDB-8583-A720BF07F997}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{98959DE3-D74C-4CDB-8583-A720BF07F997}.Release|Any CPU.Build.0 = Release|Any CPU
+		{98959DE3-D74C-4CDB-8583-A720BF07F997}.ReleaseSML|Any CPU.ActiveCfg = ReleaseSML|Any CPU
+		{98959DE3-D74C-4CDB-8583-A720BF07F997}.ReleaseSML|Any CPU.Build.0 = ReleaseSML|Any CPU
 		{98959DE3-D74C-4CDB-8583-A720BF07F997}.ReleaseLegacy|Any CPU.ActiveCfg = ReleaseLegacy|Any CPU
 		{98959DE3-D74C-4CDB-8583-A720BF07F997}.ReleaseLegacy|Any CPU.Build.0 = ReleaseLegacy|Any CPU
 	EndGlobalSection

--- a/CyclopsDockingMod/BaseItem.cs
+++ b/CyclopsDockingMod/BaseItem.cs
@@ -1,10 +1,20 @@
 ﻿using UnityEngine;
+#if SUBNAUTICA_NAUTILUS
+using System.Diagnostics.CodeAnalysis;
+#endif
 
 namespace CyclopsDockingMod
 {
+#if SUBNAUTICA_NAUTILUS
+    public abstract class BaseItem : Nautilus.Assets.CustomPrefab, IBaseItem
+    {
+        [SetsRequiredMembers]
+        protected BaseItem(Nautilus.Assets.PrefabInfo info) : base(info) { }
+#else
     public abstract class BaseItem : SMLHelper.V2.Assets.ModPrefab, IBaseItem
     {
         protected BaseItem() : base("", "") { }
+#endif
 
         public const string DefaultResourcePath = "WorldEntities/Environment/Wrecks/";
 
@@ -14,16 +24,30 @@ namespace CyclopsDockingMod
 
         public GameObject GameObject { get; set; }
 
+#if SUBNAUTICA_NAUTILUS
+        public Nautilus.Crafting.RecipeData Recipe { get; set; }
+        public string ClassID => Info.ClassID;
+        public string PrefabFileName => Info.PrefabFileName;
+        public TechType TechType => Info.TechType;
+        public abstract GameObject GetGameObject();
+#else
         public SMLHelper.V2.Crafting.TechData Recipe { get; set; }
+#endif
 
         public virtual void RegisterItem()
         {
             if (this.IsRegistered == false && this.GameObject != null)
             {
                 if (this.Recipe != null)
+#if SUBNAUTICA_NAUTILUS
+                    Nautilus.Handlers.CraftDataHandler.SetRecipeData(this.Info.TechType, this.Recipe);
+
+                this.Register();
+#else
                     SMLHelper.V2.Handlers.CraftDataHandler.SetTechData(this.TechType, this.Recipe);
 
                 SMLHelper.V2.Handlers.PrefabHandler.RegisterPrefab(this);
+#endif
 
                 this.IsRegistered = true;
             }

--- a/CyclopsDockingMod/BaseItem.cs
+++ b/CyclopsDockingMod/BaseItem.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 #if SUBNAUTICA_NAUTILUS
+using Nautilus.Assets;
 using System.Diagnostics.CodeAnalysis;
 #endif
 
@@ -9,7 +10,24 @@ namespace CyclopsDockingMod
     public abstract class BaseItem : Nautilus.Assets.CustomPrefab, IBaseItem
     {
         [SetsRequiredMembers]
-        protected BaseItem(Nautilus.Assets.PrefabInfo info) : base(info) { }
+        public BaseItem(string classID, string name, string desc, string icon) : this(
+            PrefabInfo.WithTechType(classID, name, desc, unlockAtStart: true)
+            .WithFileName(DefaultResourcePath + classID)
+            .WithIcon(AssetsHelper.Assets.LoadAsset<Sprite>(icon)))
+        { }
+
+        [SetsRequiredMembers]
+        public BaseItem(string classID, string name, string desc, Atlas.Sprite icon) : this(
+            PrefabInfo.WithTechType(classID, name, desc, unlockAtStart: true)
+            .WithFileName(DefaultResourcePath + classID)
+            .WithIcon(icon))
+        { }
+
+        [SetsRequiredMembers]
+        protected BaseItem(PrefabInfo info) : base(info)
+        {
+            SetGameObject(GetGameObject);
+        }
 #else
     public abstract class BaseItem : SMLHelper.V2.Assets.ModPrefab, IBaseItem
     {

--- a/CyclopsDockingMod/ConfigOptions.cs
+++ b/CyclopsDockingMod/ConfigOptions.cs
@@ -70,7 +70,7 @@ namespace CyclopsDockingMod
 				int num;
 				if (str.Length <= "autoDockingRange=".Length || str.Length > 10 + "autoDockingRange=".Length || !int.TryParse(str.Substring("autoDockingRange=".Length), NumberStyles.Integer, CultureInfo.InvariantCulture, out num))
 				{
-					Logger.Log("WARNING: Bad value « " + str.Substring("autoDockingRange=".Length) + " » for autoDockingRange (must be between 10 and 50). Default value will be used.");
+					Logger.Warning("Bad value « " + str.Substring("autoDockingRange=".Length) + " » for autoDockingRange (must be between 10 and 50). Default value will be used.");
 					return;
 				}
 				if (num >= 10 && num <= 50)
@@ -80,17 +80,17 @@ namespace CyclopsDockingMod
 					SubControlFixer.AutoDockingTriggerSqrRange = Mathf.Pow((float)num, 2f);
 					SubControlFixer.AutoDockingUndockSqrRange = Mathf.Pow((float)num + 5f, 2f);
 					SubControlFixer.AutoDockingDetectSqrRange = Mathf.Pow((float)num + 6f, 2f);
-					Logger.Log("INFO: Loaded autoDockingRange: " + num.ToString(CultureInfo.InvariantCulture) + "m");
+					Logger.Info("Loaded autoDockingRange: " + num.ToString(CultureInfo.InvariantCulture) + "m");
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + num.ToString(CultureInfo.InvariantCulture) + " » for autoDockingRange (must be between 10 and 50). Default value will be used.");
+				Logger.Warning("Bad value « " + num.ToString(CultureInfo.InvariantCulture) + " » for autoDockingRange (must be between 10 and 50). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("enableManualDocking="))
 			{
 				if (str.Length <= "enableManualDocking=".Length || str.Length > 20 + "enableManualDocking=".Length)
 				{
-					Logger.Log("WARNING: Bad value « " + str.Substring("enableManualDocking=".Length) + " » for manual docking toggle (must be between 1 and 20 characters maximum). Default value will be used.");
+					Logger.Warning("Bad value « " + str.Substring("enableManualDocking=".Length) + " » for manual docking toggle (must be between 1 and 20 characters maximum). Default value will be used.");
 					return;
 				}
 				bool flag;
@@ -99,10 +99,10 @@ namespace CyclopsDockingMod
 					CyclopsDockingModUI.CfgManualDockingMode = flag;
 					CyclopsDockingModUI.CfgManualDockingModeOrig = flag;
 					SubControlFixer.AutoDocking = !flag;
-					Logger.Log("INFO: Loaded enableManualDocking: " + (flag ? "true" : "false"));
+					Logger.Info("Loaded enableManualDocking: " + (flag ? "true" : "false"));
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("enableManualDocking=".Length) + " » for manual docking toggle (wrong boolean string value). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("enableManualDocking=".Length) + " » for manual docking toggle (wrong boolean string value). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("openModSettingsKey="))
@@ -112,10 +112,10 @@ namespace CyclopsDockingMod
 				{
 					CyclopsDockingModUI.CfgOpenUIKeyText = keyCode.ToString();
 					CyclopsDockingModUI.OpenUI = keyCode;
-					Logger.Log("INFO: Loaded openModSettingsKey: " + keyCode.ToString());
+					Logger.Info("Loaded openModSettingsKey: " + keyCode.ToString());
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("openModSettingsKey=".Length) + " » for openModSettingsKey (must be a valid KeyCode string and have between 1 and 20 characters maximum). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("openModSettingsKey=".Length) + " » for openModSettingsKey (must be a valid KeyCode string and have between 1 and 20 characters maximum). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("manualDockingKey="))
@@ -125,10 +125,10 @@ namespace CyclopsDockingMod
 				{
 					CyclopsDockingModUI.CfgManualDockingKeyText = keyCode2.ToString();
 					SubControlFixer.ManualDockingKey = keyCode2;
-					Logger.Log("INFO: Loaded manualDockingKey: " + keyCode2.ToString());
+					Logger.Info("Loaded manualDockingKey: " + keyCode2.ToString());
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("manualDockingKey=".Length) + " » for manualDockingKey (must be a valid KeyCode string and have between 1 and 20 characters maximum). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("manualDockingKey=".Length) + " » for manualDockingKey (must be a valid KeyCode string and have between 1 and 20 characters maximum). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("powercellsChargeSpeed="))
@@ -136,7 +136,7 @@ namespace CyclopsDockingMod
 				int num2;
 				if (str.Length <= "powercellsChargeSpeed=".Length || str.Length > 10 + "powercellsChargeSpeed=".Length || !int.TryParse(str.Substring("powercellsChargeSpeed=".Length), NumberStyles.Integer, CultureInfo.InvariantCulture, out num2))
 				{
-					Logger.Log("WARNING: Bad value « " + str.Substring("powercellsChargeSpeed=".Length) + " » for powercellsChargeSpeed (must be between 1 and 100). Default value will be used.");
+					Logger.Warning("Bad value « " + str.Substring("powercellsChargeSpeed=".Length) + " » for powercellsChargeSpeed (must be between 1 and 100). Default value will be used.");
 					return;
 				}
 				if (num2 >= 1 && num2 <= 100)
@@ -144,10 +144,10 @@ namespace CyclopsDockingMod
 					CyclopsDockingModUI.CfgRechargeSpeed = (float)num2;
 					CyclopsDockingModUI.CfgRechargeSpeedOrig = CyclopsDockingModUI.CfgRechargeSpeed;
 					SubRootFixer.CyclopsRechargeSpeed = CyclopsDockingModUI.CfgRechargeSpeed * 0.0004f;
-					Logger.Log("INFO: Loaded powercellsChargeSpeed: " + num2.ToString(CultureInfo.InvariantCulture) + "/100");
+					Logger.Info("Loaded powercellsChargeSpeed: " + num2.ToString(CultureInfo.InvariantCulture) + "/100");
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + num2.ToString(CultureInfo.InvariantCulture) + " » for powercellsChargeSpeed (must be between 1 and 100). Default value will be used.");
+				Logger.Warning("Bad value « " + num2.ToString(CultureInfo.InvariantCulture) + " » for powercellsChargeSpeed (must be between 1 and 100). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("noCyclopsText="))
@@ -155,10 +155,10 @@ namespace CyclopsDockingMod
 				if (str.Length > "noCyclopsText=".Length && str.Length <= 40 + "noCyclopsText=".Length)
 				{
 					ConfigOptions.LblNoCyclopsDocked = str.Substring("noCyclopsText=".Length);
-					Logger.Log("INFO: Loaded noCyclopsText: « " + ConfigOptions.LblNoCyclopsDocked + " »");
+					Logger.Info("Loaded noCyclopsText: « " + ConfigOptions.LblNoCyclopsDocked + " »");
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("noCyclopsText=".Length) + " » for noCyclopsText (must be between 1 and 40 characters maximum). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("noCyclopsText=".Length) + " » for noCyclopsText (must be between 1 and 40 characters maximum). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("cyclopsDockedText="))
@@ -166,10 +166,10 @@ namespace CyclopsDockingMod
 				if (str.Length > "cyclopsDockedText=".Length && str.Length <= 40 + "cyclopsDockedText=".Length && str.Contains("{0}"))
 				{
 					ConfigOptions.LblCyclopsDocked = str.Substring("cyclopsDockedText=".Length);
-					Logger.Log("INFO: Loaded cyclopsDockedText: « " + ConfigOptions.LblCyclopsDocked + " »");
+					Logger.Info("Loaded cyclopsDockedText: « " + ConfigOptions.LblCyclopsDocked + " »");
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("cyclopsDockedText=".Length) + " » for cyclopsDockedText (string must contain the special symbol and must be between 1 and 40 characters maximum). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("cyclopsDockedText=".Length) + " » for cyclopsDockedText (string must contain the special symbol and must be between 1 and 40 characters maximum). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("climbIntoCyclopsText="))
@@ -177,10 +177,10 @@ namespace CyclopsDockingMod
 				if (str.Length > "climbIntoCyclopsText=".Length && str.Length <= 40 + "climbIntoCyclopsText=".Length)
 				{
 					ConfigOptions.LblClimbInCyclops = str.Substring("climbIntoCyclopsText=".Length);
-					Logger.Log("INFO: Loaded climbIntoCyclopsText: « " + ConfigOptions.LblClimbInCyclops + " »");
+					Logger.Info("Loaded climbIntoCyclopsText: « " + ConfigOptions.LblClimbInCyclops + " »");
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("climbIntoCyclopsText=".Length) + " » for climbIntoCyclopsText (must be between 1 and 40 characters maximum). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("climbIntoCyclopsText=".Length) + " » for climbIntoCyclopsText (must be between 1 and 40 characters maximum). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("defaultTextSize="))
@@ -188,17 +188,17 @@ namespace CyclopsDockingMod
 				int num3;
 				if (str.Length <= "defaultTextSize=".Length || str.Length > 20 + "defaultTextSize=".Length || !int.TryParse(str.Substring("defaultTextSize=".Length), NumberStyles.Integer, CultureInfo.InvariantCulture, out num3))
 				{
-					Logger.Log("WARNING: Bad value « " + str.Substring("defaultTextSize=".Length) + " » for sign's text size (must be between -3 and 3). Default value will be used.");
+					Logger.Warning("Bad value « " + str.Substring("defaultTextSize=".Length) + " » for sign's text size (must be between -3 and 3). Default value will be used.");
 					return;
 				}
 				if (num3 >= -3 && num3 <= 3)
 				{
 					CyclopsDockingModUI.CfgSignTextScale = num3;
 					CyclopsDockingModUI.CfgSignTextScaleOrig = CyclopsDockingModUI.CfgSignTextScale;
-					Logger.Log("INFO: Loaded defaultTextSize: " + CyclopsDockingModUI.CfgSignTextScale.ToString(CultureInfo.InvariantCulture));
+					Logger.Info("Loaded defaultTextSize: " + CyclopsDockingModUI.CfgSignTextScale.ToString(CultureInfo.InvariantCulture));
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + num3.ToString(CultureInfo.InvariantCulture) + " » for sign's text size (must be between -3 and 3). Default value will be used.");
+				Logger.Warning("Bad value « " + num3.ToString(CultureInfo.InvariantCulture) + " » for sign's text size (must be between -3 and 3). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("defaultTextColor="))
@@ -206,7 +206,7 @@ namespace CyclopsDockingMod
 				int num4;
 				if (str.Length <= "defaultTextColor=".Length || str.Length > 20 + "defaultTextColor=".Length || !int.TryParse(str.Substring("defaultTextColor=".Length), NumberStyles.Integer, CultureInfo.InvariantCulture, out num4))
 				{
-					Logger.Log("WARNING: Bad value « " + str.Substring("defaultTextColor=".Length) + " » for sign's text color (must be between 0 and 7). Default value will be used.");
+					Logger.Warning("Bad value « " + str.Substring("defaultTextColor=".Length) + " » for sign's text color (must be between 0 and 7). Default value will be used.");
 					return;
 				}
 				if (num4 >= 0 && num4 <= 7)
@@ -214,17 +214,17 @@ namespace CyclopsDockingMod
 					CyclopsDockingModUI.CfgSignTextColorVal = num4;
 					CyclopsDockingModUI.CfgSignTextColor = CyclopsDockingModUI.CfgSignTextColors[num4];
 					CyclopsDockingModUI.CfgSignTextColorOrig = CyclopsDockingModUI.CfgSignTextColor;
-					Logger.Log("INFO: Loaded defaultTextColor: " + CyclopsDockingModUI.CfgSignTextColor);
+					Logger.Info("Loaded defaultTextColor: " + CyclopsDockingModUI.CfgSignTextColor);
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + num4.ToString(CultureInfo.InvariantCulture) + " » for sign's text color (must be between 0 and 7). Default value will be used.");
+				Logger.Warning("Bad value « " + num4.ToString(CultureInfo.InvariantCulture) + " » for sign's text color (must be between 0 and 7). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("defaultBackground="))
 			{
 				if (str.Length <= "defaultBackground=".Length || str.Length > 20 + "defaultBackground=".Length)
 				{
-					Logger.Log("WARNING: Bad value « " + str.Substring("defaultBackground=".Length) + " » for sign's background visibility (must be between 1 and 20 characters maximum). Default value will be used.");
+					Logger.Warning("Bad value « " + str.Substring("defaultBackground=".Length) + " » for sign's background visibility (must be between 1 and 20 characters maximum). Default value will be used.");
 					return;
 				}
 				bool flag2;
@@ -232,10 +232,10 @@ namespace CyclopsDockingMod
 				{
 					CyclopsDockingModUI.CfgSignBackgroundVisible = flag2;
 					CyclopsDockingModUI.CfgSignBackgroundVisibleOrig = flag2;
-					Logger.Log("INFO: Loaded defaultBackground: " + (flag2 ? "true" : "false"));
+					Logger.Info("Loaded defaultBackground: " + (flag2 ? "true" : "false"));
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("defaultBackground=".Length) + " » for sign's background visibility (wrong boolean string value). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("defaultBackground=".Length) + " » for sign's background visibility (wrong boolean string value). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("ladderTintColor="))
@@ -243,7 +243,7 @@ namespace CyclopsDockingMod
 				int num5;
 				if (str.Length <= "ladderTintColor=".Length || str.Length > 10 + "ladderTintColor=".Length || !int.TryParse(str.Substring("ladderTintColor=".Length), NumberStyles.Integer, CultureInfo.InvariantCulture, out num5))
 				{
-					Logger.Log("WARNING: Bad value « " + str.Substring("ladderTintColor=".Length) + " » for ladder's tint color (must be between 0 and 9). Default value will be used.");
+					Logger.Warning("Bad value « " + str.Substring("ladderTintColor=".Length) + " » for ladder's tint color (must be between 0 and 9). Default value will be used.");
 					return;
 				}
 				if (num5 >= 0 && num5 <= 9)
@@ -251,10 +251,10 @@ namespace CyclopsDockingMod
 					CyclopsDockingModUI.CfgLadderTintColorVal = num5;
 					CyclopsDockingModUI.CfgLadderTintColor = CyclopsDockingModUI.CfgLadderTintColors[num5];
 					CyclopsDockingModUI.CfgLadderTintColorOrig = CyclopsDockingModUI.CfgLadderTintColor;
-					Logger.Log("INFO: Loaded ladderTintColor: " + CyclopsDockingModUI.CfgLadderTintColor);
+					Logger.Info("Loaded ladderTintColor: " + CyclopsDockingModUI.CfgLadderTintColor);
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + num5.ToString(CultureInfo.InvariantCulture) + " » for ladder's tint color (must be between 0 and 9). Default value will be used.");
+				Logger.Warning("Bad value « " + num5.ToString(CultureInfo.InvariantCulture) + " » for ladder's tint color (must be between 0 and 9). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("basePieceName="))
@@ -262,10 +262,10 @@ namespace CyclopsDockingMod
 				if (str.Length > "basePieceName=".Length && str.Length <= 40 + "basePieceName=".Length)
 				{
 					CyclopsHatchConnector.CyclopsHatchConnectorName = str.Substring("basePieceName=".Length);
-					Logger.Log("INFO: Loaded basePieceName: « " + CyclopsHatchConnector.CyclopsHatchConnectorName + " »");
+					Logger.Info("Loaded basePieceName: « " + CyclopsHatchConnector.CyclopsHatchConnectorName + " »");
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("basePieceName=".Length) + " » for basePieceName (must be between 1 and 40 characters maximum). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("basePieceName=".Length) + " » for basePieceName (must be between 1 and 40 characters maximum). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("basePieceDescription="))
@@ -273,17 +273,17 @@ namespace CyclopsDockingMod
 				if (str.Length > "basePieceDescription=".Length && str.Length <= 200 + "basePieceDescription=".Length)
 				{
 					CyclopsHatchConnector.CyclopsHatchConnectorDescription = str.Substring("basePieceDescription=".Length);
-					Logger.Log("INFO: Loaded basePieceDescription: « " + CyclopsHatchConnector.CyclopsHatchConnectorDescription + " »");
+					Logger.Info("Loaded basePieceDescription: « " + CyclopsHatchConnector.CyclopsHatchConnectorDescription + " »");
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("basePieceName=".Length) + " » for basePieceName (must be between 1 and 200 characters maximum). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("basePieceName=".Length) + " » for basePieceName (must be between 1 and 200 characters maximum). Default value will be used.");
 				return;
 			}
 			else if (str.StartsWith("basePieceRecipe="))
 			{
 				if (str.Length <= "basePieceRecipe=".Length || str.Length > 200 + "basePieceRecipe=".Length)
 				{
-					Logger.Log("WARNING: Bad value « " + str.Substring("basePieceRecipe=".Length) + " » for basePieceRecipe (must be between 1 and 200 characters maximum). Default value will be used.");
+					Logger.Warning("Bad value « " + str.Substring("basePieceRecipe=".Length) + " » for basePieceRecipe (must be between 1 and 200 characters maximum). Default value will be used.");
 					return;
 				}
 				List<TechType> list = ConfigOptions.ParseIngredients(str.Substring("basePieceRecipe=".Length));
@@ -295,27 +295,27 @@ namespace CyclopsDockingMod
 					{
 						text = text + ((text.Length > 0) ? "," : "") + techType.AsString(false);
 					}
-					Logger.Log("INFO: Loaded basePieceRecipe: " + text);
+					Logger.Info("Loaded basePieceRecipe: " + text);
 					return;
 				}
-				Logger.Log("WARNING: Bad recipe provided for Cyclops docking base piece. Default recipe will be used.");
+				Logger.Warning("Bad recipe provided for Cyclops docking base piece. Default recipe will be used.");
 				return;
 			}
 			else if (str.StartsWith("enableAutoPilotFeature="))
 			{
 				if (str.Length <= "enableAutoPilotFeature=".Length || str.Length > 20 + "enableAutoPilotFeature=".Length)
 				{
-					Logger.Log("WARNING: Bad value « " + str.Substring("enableAutoPilotFeature=".Length) + " » for auto-pilot feature toggle (must be between 1 and 20 characters maximum). Default value will be used.");
+					Logger.Warning("Bad value « " + str.Substring("enableAutoPilotFeature=".Length) + " » for auto-pilot feature toggle (must be between 1 and 20 characters maximum). Default value will be used.");
 					return;
 				}
 				bool flag3;
 				if (bool.TryParse(str.Substring("enableAutoPilotFeature=".Length), out flag3))
 				{
 					ConfigOptions.EnableAutopilotFeature = flag3;
-					Logger.Log("INFO: Loaded enableAutoPilotFeature: " + (flag3 ? "true" : "false"));
+					Logger.Info("Loaded enableAutoPilotFeature: " + (flag3 ? "true" : "false"));
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("enableAutoPilotFeature=".Length) + " » for auto-pilot feature toggle (wrong boolean string value). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("enableAutoPilotFeature=".Length) + " » for auto-pilot feature toggle (wrong boolean string value). Default value will be used.");
 				return;
 			}
 			else
@@ -328,9 +328,9 @@ namespace CyclopsDockingMod
 						{
 							if (str.Length <= keyValuePair.Key.Length || str.Length > keyValuePair.Value + keyValuePair.Key.Length)
 							{
-								Logger.Log(string.Concat(new string[]
+								Logger.Warning(string.Concat(new string[]
 								{
-									"WARNING: Bad value « ",
+									"Bad value « ",
 									str.Substring(keyValuePair.Key.Length),
 									" » for ",
 									keyValuePair.Key.TrimEnd(new char[] { '=' }),
@@ -341,9 +341,9 @@ namespace CyclopsDockingMod
 								break;
 							}
 							string text2 = str.Substring(keyValuePair.Key.Length);
-							Logger.Log(string.Concat(new string[]
+							Logger.Info(string.Concat(new string[]
 							{
-								"INFO: Loaded ",
+								"Loaded ",
 								keyValuePair.Key.Replace('=', ':'),
 								" « ",
 								text2,
@@ -491,7 +491,7 @@ namespace CyclopsDockingMod
 				}
 				if (str.Length <= "simpleDockingManeuver=".Length || str.Length > 20 + "simpleDockingManeuver=".Length)
 				{
-					Logger.Log("WARNING: Bad value « " + str.Substring("simpleDockingManeuver=".Length) + " » for simple docking maneuver toggle (must be between 1 and 20 characters maximum). Default value will be used.");
+					Logger.Warning("Bad value « " + str.Substring("simpleDockingManeuver=".Length) + " » for simple docking maneuver toggle (must be between 1 and 20 characters maximum). Default value will be used.");
 					return;
 				}
 				bool flag4;
@@ -500,10 +500,10 @@ namespace CyclopsDockingMod
 					CyclopsDockingModUI.CfgSimpleDockingManeuver = flag4;
 					CyclopsDockingModUI.CfgSimpleDockingManeuverOrig = flag4;
 					SubControlFixer.SimpleDocking = flag4;
-					Logger.Log("INFO: Loaded simpleDockingManeuver: " + (flag4 ? "true" : "false"));
+					Logger.Info("Loaded simpleDockingManeuver: " + (flag4 ? "true" : "false"));
 					return;
 				}
-				Logger.Log("WARNING: Bad value « " + str.Substring("simpleDockingManeuver=".Length) + " » for simple docking maneuver toggle (wrong boolean string value). Default value will be used.");
+				Logger.Warning("Bad value « " + str.Substring("simpleDockingManeuver=".Length) + " » for simple docking maneuver toggle (wrong boolean string value). Default value will be used.");
 				return;
 			}
 		}
@@ -537,30 +537,30 @@ namespace CyclopsDockingMod
 				ConfigOptions.ConfigFilePath = FilesHelper.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "Config.txt");
 			if (ConfigOptions.ConfigFilePath == null)
 			{
-				Logger.Log("WARNING: Cannot find configuration file path. Default settings will be used.");
+				Logger.Warning("Cannot find configuration file path. Default settings will be used.");
 				return;
 			}
 			if (!File.Exists(ConfigOptions.ConfigFilePath))
 			{
-				Logger.Log("WARNING: Cannot find configuration at \"" + ConfigOptions.ConfigFilePath + "\". Default settings will be used.");
+				Logger.Warning("Cannot find configuration at \"" + ConfigOptions.ConfigFilePath + "\". Default settings will be used.");
 				return;
 			}
 			string text = File.ReadAllText(ConfigOptions.ConfigFilePath, Encoding.UTF8);
 			if (text == null)
 			{
-				Logger.Log("WARNING: Could not read configuration file at \"" + ConfigOptions.ConfigFilePath + "\". Default settings will be used.");
+				Logger.Warning("Could not read configuration file at \"" + ConfigOptions.ConfigFilePath + "\". Default settings will be used.");
 				return;
 			}
 			string[] array = text.Split(Environment.NewLine.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
 			if (array != null)
 			{
-				Logger.Log("INFO: Loading configuration from \"" + ConfigOptions.ConfigFilePath + "\"...");
+				Logger.Info("Loading configuration from \"" + ConfigOptions.ConfigFilePath + "\"...");
 				string[] array2 = array;
 				for (int i = 0; i < array2.Length; i++)
 					ConfigOptions.ProcessConfigLine(array2[i]);
 				return;
 			}
-			Logger.Log("WARNING: Configuration file at \"" + ConfigOptions.ConfigFilePath + "\" is empty. Default settings will be used.");
+			Logger.Warning("Configuration file at \"" + ConfigOptions.ConfigFilePath + "\" is empty. Default settings will be used.");
 		}
 
 		public static void UpdateConfigFile(string oldStr, string newStr)
@@ -583,9 +583,9 @@ namespace CyclopsDockingMod
 								if (num2 > num && num2 < text.Length)
 								{
 									string text4 = text.Substring(num, num2 - num) + Environment.NewLine;
-									Logger.Log(string.Concat(new string[]
+									Logger.Info(string.Concat(new string[]
 									{
-										"INFO: Replacing configuration [",
+										"Replacing configuration [",
 										text4.Replace(Environment.NewLine, ""),
 										"] by [",
 										newStr.Replace(Environment.NewLine, ""),
@@ -604,7 +604,7 @@ namespace CyclopsDockingMod
 				catch
 				{
 					string text5 = "An error happened while updating config file at \"" + ConfigOptions.ConfigFilePath + "\"!";
-					Logger.Log("ERROR: " + text5);
+					Logger.Error(text5);
 					ErrorMessage.AddDebug(text5);
 				}
 			}

--- a/CyclopsDockingMod/CyclopsDockingMod.cs
+++ b/CyclopsDockingMod/CyclopsDockingMod.cs
@@ -31,7 +31,7 @@ namespace CyclopsDockingMod
 		{
 			if ((CyclopsDockingMod.HarmonyInstance = new Harmony("com.osubmarin.cyclopsdockingmod")) == null)
 			{
-				Logger.Log("ERROR: Unable to initialize Harmony!");
+				Logger.Error("Unable to initialize Harmony!");
 				return false;
 			}
 			return true;
@@ -69,13 +69,13 @@ namespace CyclopsDockingMod
 			if (method11 != null && method12 != null)
 				CyclopsDockingMod.HarmonyInstance.Patch(method11, null, new HarmonyMethod(method12), null, null, null);
 			else
-				Logger.Log("ERROR: Failed to find BeginAsync methods.");
+				Logger.Error("Failed to find BeginAsync methods.");
 			MethodInfo method13 = typeof(Builder).GetMethod("CreateGhost", BindingFlags.Static | BindingFlags.NonPublic);
 			MethodInfo method14 = typeof(BuilderFixer).GetMethod("CreateGhost_Prefix", BindingFlags.Static | BindingFlags.Public);
 			if (method13 != null && method14 != null)
 				CyclopsDockingMod.HarmonyInstance.Patch(method13, new HarmonyMethod(method14), null, null, null, null);
 			else
-				Logger.Log("ERROR: Failed to find CreateGhost methods.");
+				Logger.Error("Failed to find CreateGhost methods.");
 			MethodInfo method15 = typeof(BaseGhost).GetMethod("Place", BindingFlags.Instance | BindingFlags.Public);
 			MethodInfo method16 = typeof(BaseGhostFixer).GetMethod("Place_Prefix", BindingFlags.Static | BindingFlags.Public);
 			CyclopsDockingMod.HarmonyInstance.Patch(method15, new HarmonyMethod(method16), null, null, null, null);

--- a/CyclopsDockingMod/CyclopsDockingMod.csproj
+++ b/CyclopsDockingMod/CyclopsDockingMod.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net472</TargetFramework>
     <AssemblyName>CyclopsDockingMod</AssemblyName>
     <Description>A mod for Subnautica that adds a docking base piece to dock your Cyclops. Also adds Cyclops autopilot feature.</Description>
     <Version>2.0.8</Version>
@@ -11,7 +11,7 @@
     <PackageId>CyclopsDockingMod</PackageId>
     <Copyright>Copyright © 2019-2023. Tous droits réservés.</Copyright>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>11</LangVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <OutputType>Library</OutputType>
@@ -20,9 +20,24 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
-    <Configurations>Debug;Release;DebugLegacy;ReleaseLegacy</Configurations>
+    <Configurations>Debug;Release;DebugLegacy;ReleaseLegacy;DebugSML;ReleaseSML</Configurations>
+    <RestoreAdditionalProjectSources>
+      https://api.nuget.org/v3/index.json;
+      https://nuget.bepinex.dev/v3/index.json;
+    </RestoreAdditionalProjectSources>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;SUBNAUTICA;SUBNAUTICA_EXP;SUBNAUTICA_NAUTILUS;DEBUG_CURSOR_LOCK;DEBUG_AUTOPILOT_CLICK;DEBUG_CYCLOPS_HUD</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <SubnauticaDir>S:\Steam\steamapps\common\Subnautica</SubnauticaDir>
+    <Dependencies>$(SubnauticaDir)\Subnautica_Data\Managed</Dependencies>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugSML|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -30,10 +45,10 @@
     <DefineConstants>TRACE;DEBUG;SUBNAUTICA;SUBNAUTICA_EXP;DEBUG_CURSOR_LOCK;DEBUG_AUTOPILOT_CLICK;DEBUG_CYCLOPS_HUD</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <SubnauticaDir>H:\SteamLibrary\steamapps\common\Subnautica</SubnauticaDir>
+    <SubnauticaDir>S:\Steam\steamapps\common\Subnautica</SubnauticaDir>
     <Dependencies>$(SubnauticaDir)\Subnautica_Data\Managed</Dependencies>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DebugLegacy|AnyCPU'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugLegacy|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -41,83 +56,42 @@
     <DefineConstants>TRACE;DEBUG;SUBNAUTICA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <SubnauticaDir>H:\SteamLibrary\steamapps\common\Subnautica</SubnauticaDir>
+    <SubnauticaDir>S:\Steam\steamapps\common\Subnautica</SubnauticaDir>
     <Dependencies>$(SubnauticaDir)\Subnautica_Data\Managed</Dependencies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>SUBNAUTICA;SUBNAUTICA_EXP;SUBNAUTICA_NAUTILUS;DEBUG_BEPINEX_CONFIG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>2</WarningLevel>
+    <SubnauticaDir>S:\Steam\steamapps\common\Subnautica</SubnauticaDir>
+    <Dependencies>$(SubnauticaDir)\Subnautica_Data\Managed</Dependencies>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseSML|AnyCPU' ">
+    <DebugType>none</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>SUBNAUTICA;SUBNAUTICA_EXP;DEBUG_BEPINEX_CONFIG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>2</WarningLevel>
-    <SubnauticaDir>H:\SteamLibrary\steamapps\common\Subnautica</SubnauticaDir>
+    <SubnauticaDir>S:\Steam\steamapps\common\Subnautica</SubnauticaDir>
     <Dependencies>$(SubnauticaDir)\Subnautica_Data\Managed</Dependencies>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseLegacy|AnyCPU'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseLegacy|AnyCPU' ">
     <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>SUBNAUTICA</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>2</WarningLevel>
-    <SubnauticaDir>H:\SteamLibrary\steamapps\common\Subnautica</SubnauticaDir>
+    <SubnauticaDir>S:\Steam\steamapps\common\Subnautica</SubnauticaDir>
     <Dependencies>$(SubnauticaDir)\Subnautica_Data\Managed</Dependencies>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BepInEx">
-      <HintPath>$(SubnauticaDir)\BepInEx\core\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="0Harmony">
-      <HintPath>$(SubnauticaDir)\BepInEx\core\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>$(Dependencies)\Assembly-CSharp.dll</HintPath>
-    </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>$(Dependencies)\Assembly-CSharp-firstpass.dll</HintPath>
-    </Reference>
     <Reference Include="SMLHelper">
       <HintPath>$(SubnauticaDir)\BepInEx\plugins\Modding Helper\SMLHelper.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine">
-      <HintPath>$(Dependencies)\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AnimationModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(Dependencies)\UnityEngine.AnimationModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>$(Dependencies)\UnityEngine.AssetBundleModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(Dependencies)\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>$(Dependencies)\UnityEngine.InputLegacyModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>$(Dependencies)\UnityEngine.PhysicsModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.TextRenderingModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(Dependencies)\UnityEngine.TextRenderingModule.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.TextMeshPro">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(Dependencies)\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(Dependencies)\UnityEngine.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="Unity.ResourceManager">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(Dependencies)\Unity.ResourceManager.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.IMGUIModule">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(Dependencies)\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -166,5 +140,15 @@
     <Compile Include="Routing\SubRoutePlaying.cs" />
     <Compile Include="StylesHelper.cs" />
     <Compile Include="UI\CyclopsDockingModUI.cs" />
+    <PackageReference Include="BepInEx.Analyzers" Version="1.*" PrivateAssets="all" />
+    <PackageReference Include="BepInEx.Core" Version="5.4.21" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.1.0" />
+    <PackageReference Include="UnityEngine.Modules" Version="2019.4.36" IncludeAssets="compile" />
+    <PackageReference Include="Subnautica.GameLibs" Version="71288.0.0-r.0" />
+    <PackageReference Include="PolySharp" Version="1.13.1" />
+    <PackageReference Include="Subnautica.Nautilus" Version="1.*-*" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/CyclopsDockingMod/CyclopsDockingMod.csproj
+++ b/CyclopsDockingMod/CyclopsDockingMod.csproj
@@ -151,4 +151,7 @@
   <ItemGroup Condition="'$(TargetFramework.TrimEnd(`0123456789`))' == 'net'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy /Y /I &quot;$(TargetPath)&quot; &quot;S:\Steam\steamapps\common\Subnautica\BepInEx\plugins\CyclopsDockingMod\&quot;" />
+  </Target>
 </Project>

--- a/CyclopsDockingMod/CyclopsDockingMod_EntryPoint.cs
+++ b/CyclopsDockingMod/CyclopsDockingMod_EntryPoint.cs
@@ -6,7 +6,11 @@ using UnityEngine;
 namespace CyclopsDockingMod
 {
 	[BepInPlugin("com.osubmarin.cyclopsdockingmod", "CyclopsDockingMod", "2.0.7")]
+#if SUBNAUTICA_NAUTILUS
+    [BepInDependency("com.snmodding.nautilus", BepInDependency.DependencyFlags.HardDependency)]
+#else
 	[BepInDependency("com.ahk1221.smlhelper", BepInDependency.DependencyFlags.HardDependency)]
+#endif
 	[DisallowMultipleComponent]
 	public class CyclopsDockingMod_EntryPoint : BaseUnityPlugin
     {

--- a/CyclopsDockingMod/CyclopsHatchConnector.cs
+++ b/CyclopsDockingMod/CyclopsHatchConnector.cs
@@ -1,7 +1,15 @@
 ﻿using System.Collections.Generic;
 using CyclopsDockingMod.Fixers;
+#if SUBNAUTICA_NAUTILUS
+using System.Diagnostics.CodeAnalysis;
+using Nautilus.Assets;
+using Nautilus.Crafting;
+using Nautilus.Handlers;
+using static CraftData;
+#else
 using SMLHelper.V2.Crafting;
 using SMLHelper.V2.Handlers;
+#endif
 using UnityEngine;
 
 namespace CyclopsDockingMod
@@ -23,6 +31,10 @@ namespace CyclopsDockingMod
 
         public const string ModelName = "CyclopsDockingHatchClean";
 
+#if SUBNAUTICA_NAUTILUS
+        public static string CyclopsHatchConnectorClassID = "CyclopsHatchConnector";
+
+#endif
         public static string CyclopsHatchConnectorName = "Cyclops docking hatch";
 
         public static string CyclopsHatchConnectorDescription = "A module for mooring the Cyclops to a base. Allows quick base/Cyclops transitions and recharges Cyclops powercells.";
@@ -43,15 +55,30 @@ namespace CyclopsDockingMod
             UNDOCKED
         }
 
+#if SUBNAUTICA_NAUTILUS
+        [SetsRequiredMembers]
+        public CyclopsHatchConnector() : base(
+			PrefabInfo.WithTechType(CyclopsHatchConnectorClassID, CyclopsHatchConnectorName, CyclopsHatchConnectorDescription, unlockAtStart: true)
+			.WithFileName("WorldEntities/Environment/Wrecks/" + CyclopsHatchConnectorClassID)
+			.WithIcon(AssetsHelper.Assets.LoadAsset<Sprite>("CyclopsDockingHatchIconG"))
+			)
+		{
+			base.GameObject = new GameObject(base.ClassID);
+#else
         public CyclopsHatchConnector()
 		{
 			base.ClassID = "CyclopsHatchConnector";
 			base.PrefabFileName = "WorldEntities/Environment/Wrecks/" + base.ClassID;
 			base.GameObject = new GameObject(base.ClassID);
 			base.TechType = TechTypeHandler.AddTechType(base.ClassID, CyclopsHatchConnector.CyclopsHatchConnectorName, CyclopsHatchConnector.CyclopsHatchConnectorDescription, true);
+#endif
 			CyclopsDockingMod.CyclopsHatchConnector = base.TechType;
 			this.IsHabitatBuilder = true;
+#if SUBNAUTICA_NAUTILUS
+			base.Recipe = new RecipeData
+#else
 			base.Recipe = new TechData
+#endif
 			{
 				craftAmount = 1,
 				Ingredients = this.SortIngredients()
@@ -83,11 +110,19 @@ namespace CyclopsDockingMod
 		{
 			if (!this.IsRegistered)
 			{
+#if SUBNAUTICA_NAUTILUS
+				CraftDataHandler.SetRecipeData(base.TechType, base.Recipe);
+#else
 				CraftDataHandler.SetTechData(base.TechType, base.Recipe);
+#endif
 				CraftDataHandler.AddBuildable(base.TechType);
 				CraftDataHandler.AddToGroup(TechGroup.BasePieces, TechCategory.BasePiece, base.TechType);
+#if SUBNAUTICA_NAUTILUS
+				this.Register();
+#else
 				PrefabHandler.RegisterPrefab(this);
 				SpriteHandler.RegisterSprite(base.TechType, AssetsHelper.Assets.LoadAsset<Sprite>("CyclopsDockingHatchIconG"));
+#endif
 				this.IsRegistered = true;
 			}
 		}

--- a/CyclopsDockingMod/CyclopsHatchConnector.cs
+++ b/CyclopsDockingMod/CyclopsHatchConnector.cs
@@ -31,10 +31,6 @@ namespace CyclopsDockingMod
 
         public const string ModelName = "CyclopsDockingHatchClean";
 
-#if SUBNAUTICA_NAUTILUS
-        public static string CyclopsHatchConnectorClassID = "CyclopsHatchConnector";
-
-#endif
         public static string CyclopsHatchConnectorName = "Cyclops docking hatch";
 
         public static string CyclopsHatchConnectorDescription = "A module for mooring the Cyclops to a base. Allows quick base/Cyclops transitions and recharges Cyclops powercells.";
@@ -57,13 +53,9 @@ namespace CyclopsDockingMod
 
 #if SUBNAUTICA_NAUTILUS
         [SetsRequiredMembers]
-        public CyclopsHatchConnector() : base(
-			PrefabInfo.WithTechType(CyclopsHatchConnectorClassID, CyclopsHatchConnectorName, CyclopsHatchConnectorDescription, unlockAtStart: true)
-			.WithFileName("WorldEntities/Environment/Wrecks/" + CyclopsHatchConnectorClassID)
-			.WithIcon(AssetsHelper.Assets.LoadAsset<Sprite>("CyclopsDockingHatchIconG"))
-			)
+        public CyclopsHatchConnector() : base("CyclopsHatchConnector", CyclopsHatchConnectorName, CyclopsHatchConnectorDescription, "CyclopsDockingHatchIconG")
 		{
-			base.GameObject = new GameObject(base.ClassID);
+			GameObject = new GameObject(base.ClassID);
 #else
         public CyclopsHatchConnector()
 		{
@@ -75,9 +67,9 @@ namespace CyclopsDockingMod
 			CyclopsDockingMod.CyclopsHatchConnector = base.TechType;
 			this.IsHabitatBuilder = true;
 #if SUBNAUTICA_NAUTILUS
-			base.Recipe = new RecipeData
+			Recipe = new RecipeData
 #else
-			base.Recipe = new TechData
+			Recipe = new TechData
 #endif
 			{
 				craftAmount = 1,
@@ -111,17 +103,17 @@ namespace CyclopsDockingMod
 			if (!this.IsRegistered)
 			{
 #if SUBNAUTICA_NAUTILUS
-				CraftDataHandler.SetRecipeData(base.TechType, base.Recipe);
+				CraftDataHandler.SetRecipeData(TechType, Recipe);
 #else
-				CraftDataHandler.SetTechData(base.TechType, base.Recipe);
+				CraftDataHandler.SetTechData(TechType, Recipe);
 #endif
-				CraftDataHandler.AddBuildable(base.TechType);
-				CraftDataHandler.AddToGroup(TechGroup.BasePieces, TechCategory.BasePiece, base.TechType);
+				CraftDataHandler.AddBuildable(TechType);
+				CraftDataHandler.AddToGroup(TechGroup.BasePieces, TechCategory.BasePiece, TechType);
 #if SUBNAUTICA_NAUTILUS
 				this.Register();
 #else
 				PrefabHandler.RegisterPrefab(this);
-				SpriteHandler.RegisterSprite(base.TechType, AssetsHelper.Assets.LoadAsset<Sprite>("CyclopsDockingHatchIconG"));
+				SpriteHandler.RegisterSprite(TechType, AssetsHelper.Assets.LoadAsset<Sprite>("CyclopsDockingHatchIconG"));
 #endif
 				this.IsRegistered = true;
 			}
@@ -129,12 +121,12 @@ namespace CyclopsDockingMod
 
 		public override GameObject GetGameObject()
 		{
-			if (base.GameObject == null)
-				base.GameObject = new GameObject(base.ClassID);
-			GameObject gameObject = Object.Instantiate<GameObject>(base.GameObject);
-			gameObject.name = base.ClassID;
-			gameObject.AddComponent<PrefabIdentifier>().ClassId = base.ClassID;
-			gameObject.AddComponent<TechTag>().type = base.TechType;
+			if (GameObject == null)
+				GameObject = new GameObject(ClassID);
+			GameObject gameObject = Object.Instantiate<GameObject>(GameObject);
+			gameObject.name = ClassID;
+			gameObject.AddComponent<PrefabIdentifier>().ClassId = ClassID;
+			gameObject.AddComponent<TechTag>().type = TechType;
 			Constructable constructable = gameObject.AddComponent<Constructable>();
 			constructable.allowedInBase = true;
 			constructable.allowedInSub = true;
@@ -147,7 +139,7 @@ namespace CyclopsDockingMod
 			constructable.deconstructionAllowed = true;
 			constructable.rotationEnabled = false;
 			constructable.model = gameObject;
-			constructable.techType = base.TechType;
+			constructable.techType = TechType;
 			constructable.surfaceType = VFXSurfaceTypes.metal;
 			constructable.placeMinDistance = 0.6f;
 			constructable.enabled = true;

--- a/CyclopsDockingMod/Fixers/BaseFixer.cs
+++ b/CyclopsDockingMod/Fixers/BaseFixer.cs
@@ -9,6 +9,9 @@ using Newtonsoft.Json.Linq;
 using UnityEngine;
 using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEngine.UI;
+using static ClipMapManager;
+using static OVRHaptics;
+using UnityEngine.UIElements;
 
 namespace CyclopsDockingMod.Fixers
 {
@@ -147,7 +150,7 @@ namespace CyclopsDockingMod.Fixers
 
 		public static void SaveBaseParts()
 		{
-			//string text = "";
+			string text = "";
 			List<BasePartSaveData> basePartSaveData = new List<BasePartSaveData>();
 			foreach (BasePart basePart in BaseFixer.BaseParts)
 			{
@@ -192,7 +195,25 @@ namespace CyclopsDockingMod.Fixers
                             config4 = signConfig.Item4
                         }
 					});
-				}
+					text += string.Format(CultureInfo.InvariantCulture, "{0}/{1}/{2}/{3}/{4}/{5}/{6}/{7}/{8}/{9}/{10}/{11}/{12}/{13}{14}", new object[]
+					{
+						basePart.id,
+						basePart.cell.x.ToString(CultureInfo.InvariantCulture),
+						basePart.cell.y.ToString(CultureInfo.InvariantCulture),
+						basePart.cell.z.ToString(CultureInfo.InvariantCulture),
+						basePart.index.ToString(CultureInfo.InvariantCulture),
+						basePart.position.x.ToString(CultureInfo.InvariantCulture),
+						basePart.position.y.ToString(CultureInfo.InvariantCulture),
+						basePart.position.z.ToString(CultureInfo.InvariantCulture),
+						basePart.type.ToString(CultureInfo.InvariantCulture),
+						string.IsNullOrEmpty(basePart.dock) ? "?" : basePart.dock,
+						signConfig.Item1.ToString(CultureInfo.InvariantCulture),
+						signConfig.Item2.ToString(CultureInfo.InvariantCulture),
+						signConfig.Item3 ? "True" : "False",
+						signConfig.Item4,
+						System.Environment.NewLine
+					});
+                }
             }
             string saveFolderPath = FilesHelper.GetSaveFolderPath();
             if (saveFolderPath.Contains("/test/"))
@@ -217,16 +238,11 @@ namespace CyclopsDockingMod.Fixers
                 Logger.Error("Unable to create save folder at [" + saveFolderPath + "].");
                 return;
             }
-            string text2 = FilesHelper.Combine(saveFolderPath, "baseparts.txt");
-			if (File.Exists(text2))
-			{
-				Logger.Info($"Deleting legacy baseparts info \"{text2}\"");
-				File.Delete(text2);
-            }
-            text2 = FilesHelper.Combine(saveFolderPath, "baseparts.json");
+            string text2 = FilesHelper.Combine(saveFolderPath, "baseparts.json");
+            string text3 = FilesHelper.Combine(saveFolderPath, "baseparts.txt");
             if (basePartSaveData.Count > 0)
             {
-                Logger.Info($"Saving {BaseFixer.BaseParts.Count} base parts to \"{text2}\".");
+                Logger.Info($"Saving {BaseFixer.BaseParts.Count} base parts to \"{text2}\" with legacy \"{text3}\" for backwards compatibility.");
                 try
                 {
                     File.WriteAllText(text2, JArray.FromObject(basePartSaveData).ToString(), Encoding.UTF8);
@@ -235,11 +251,41 @@ namespace CyclopsDockingMod.Fixers
                 {
                     Logger.Error($"Exception caught while saving base parts at [{text2}]. Exception=[{ex2.ToString()}]");
                 }
+                try
+                {
+                    File.WriteAllText(text3, text, Encoding.UTF8);
+                }
+                catch (System.Exception ex2)
+                {
+                    Logger.Error($"Exception caught while saving base parts at [{text3}]. Exception=[{ex2.ToString()}]");
+                }
             }
-			else if (File.Exists(text2))
-            {
-                Logger.Info($"Deleting old baseparts info \"{text2}\"");
-                File.Delete(text2);
+			else
+			{
+                if (File.Exists(text2))
+                {
+                    Logger.Info($"Deleting old baseparts info \"{text2}\"");
+                    try
+                    {
+                        File.Delete(text2);
+                    }
+                    catch (System.Exception ex2)
+                    {
+                        Logger.Error($"Exception caught while deleting old baseparts info \"{text2}\". Exception=[{ex2.ToString()}]");
+                    }
+                }
+                if (File.Exists(text3))
+                {
+                    Logger.Info($"Deleting old legacy baseparts info \"{text3}\"");
+                    try
+                    {
+                        File.Delete(text3);
+                    }
+                    catch (System.Exception ex2)
+                    {
+                        Logger.Error($"Exception caught while deleting old baseparts info \"{text3}\". Exception=[{ex2.ToString()}]");
+                    }
+                }
             }
         }
 

--- a/CyclopsDockingMod/Fixers/BaseFixer.cs
+++ b/CyclopsDockingMod/Fixers/BaseFixer.cs
@@ -64,13 +64,13 @@ namespace CyclopsDockingMod.Fixers
 			{
 				if (!Directory.Exists(saveFolderPath))
 				{
-					Logger.Log("INFO: No save directory found for base parts at \"" + saveFolderPath + "\".");
+					Logger.Info("No save directory found for base parts at \"" + saveFolderPath + "\".");
 					return;
 				}
 				string text = FilesHelper.Combine(saveFolderPath, "baseparts.txt");
 				if (File.Exists(text))
 				{
-					Logger.Log("INFO: Loading base parts from \"" + text + "\".");
+					Logger.Info("Loading base parts from \"" + text + "\".");
 					string[] array;
 					try
 					{
@@ -78,7 +78,7 @@ namespace CyclopsDockingMod.Fixers
 					}
 					catch (System.Exception ex)
 					{
-						Logger.Log("ERROR: Exception caught while loading base parts. Exception=[" + ex.ToString() + "]");
+						Logger.Error("Exception caught while loading base parts. Exception=[" + ex.ToString() + "]");
 						return;
 					}
 					if (array != null && array.Length != 0)
@@ -111,15 +111,15 @@ namespace CyclopsDockingMod.Fixers
 							}
 						}
 					}
-					Logger.Log("INFO: Base parts loaded. Player built {0} custom base parts.", new object[] { BaseFixer.BaseParts.Count });
+					Logger.Info("Base parts loaded. Player built {0} custom base parts.", new object[] { BaseFixer.BaseParts.Count });
 					return;
 				}
-				Logger.Log("INFO: No base parts saved at \"" + text + "\".");
+				Logger.Info("No base parts saved at \"" + text + "\".");
 				return;
 			}
 			else
 			{
-				Logger.Log("INFO: Could not find save slot for base parts.");
+				Logger.Info("Could not find save slot for base parts.");
 			}
 		}
 
@@ -167,7 +167,7 @@ namespace CyclopsDockingMod.Fixers
 				string saveFolderPath = FilesHelper.GetSaveFolderPath();
 				if (saveFolderPath.Contains("/test/"))
 				{
-					Logger.Log("ERROR: Unable to find save folder path at [" + saveFolderPath + "].");
+					Logger.Error("Unable to find save folder path at [" + saveFolderPath + "].");
 					return;
 				}
 				if (!Directory.Exists(saveFolderPath))
@@ -178,23 +178,23 @@ namespace CyclopsDockingMod.Fixers
 					}
 					catch (System.Exception ex)
 					{
-						Logger.Log($"ERROR: Exception caught while creating folder at [{saveFolderPath}]. Exception=[{ex.ToString()}]");
+						Logger.Error($"Exception caught while creating folder at [{saveFolderPath}]. Exception=[{ex.ToString()}]");
 					}
 				}
 				if (!Directory.Exists(saveFolderPath))
 				{
-					Logger.Log("ERROR: Unable to create save folder at [" + saveFolderPath + "].");
+					Logger.Error("Unable to create save folder at [" + saveFolderPath + "].");
 					return;
 				}
 				string text2 = FilesHelper.Combine(saveFolderPath, "baseparts.txt");
-				Logger.Log($"INFO: Saving {BaseFixer.BaseParts.Count} base parts to \"{text2}\".");
+				Logger.Info($"Saving {BaseFixer.BaseParts.Count} base parts to \"{text2}\".");
 				try
 				{
 					File.WriteAllText(text2, text, Encoding.UTF8);
 				}
 				catch (System.Exception ex2)
 				{
-					Logger.Log($"ERROR: Exception caught while saving base parts at [{text2}]. Exception=[{ex2.ToString()}]");
+					Logger.Error($"Exception caught while saving base parts at [{text2}]. Exception=[{ex2.ToString()}]");
 				}
 			}
 		}

--- a/CyclopsDockingMod/Fixers/SubControlFixer.cs
+++ b/CyclopsDockingMod/Fixers/SubControlFixer.cs
@@ -336,7 +336,7 @@ namespace CyclopsDockingMod.Fixers
 			}
 			catch (Exception ex)
 			{
-				Logger.Log("ERROR: Exception caught in Throttle. Ex=[" + ex.ToString() + "]");
+				Logger.Error("Exception caught in Throttle. Ex=[" + ex.ToString() + "]");
 			}
 		}
 

--- a/CyclopsDockingMod/Fixers/SubRootFixer.cs
+++ b/CyclopsDockingMod/Fixers/SubRootFixer.cs
@@ -60,7 +60,7 @@ namespace CyclopsDockingMod.Fixers
 				float sqrMagnitude = vector.sqrMagnitude;
 				if (sqrMagnitude > SubControlFixer.AutoDockingTriggerSqrRange)
 				{
-					string text = "INFO: Found Cyclops docked but too far away from dock ({0}m) at coordinates {1} {2} {3}. Undocking it.";
+					string text = "Found Cyclops docked but too far away from dock ({0}m) at coordinates {1} {2} {3}. Undocking it.";
 					object[] array = new object[4];
 					array[0] = Mathf.Sqrt(sqrMagnitude).ToString("0.00", CultureInfo.InvariantCulture);
 					int num = 1;
@@ -72,7 +72,7 @@ namespace CyclopsDockingMod.Fixers
 					int num3 = 3;
 					vector = transform.position;
 					array[num3] = vector.z.ToString("0.00", CultureInfo.InvariantCulture);
-					Logger.Log(text, array);
+					Logger.Info(text, array);
 					SubControlFixer.CleanUp(SubControlFixer.DockedSubs[component.Id], component.Id, true);
 					SubControlFixer.ToggleTrap(__instance, false, false);
 					if (SubControlFixer.DockedSubs[component.Id].trapOpened)

--- a/CyclopsDockingMod/Fixers/uGUI_MainMenuFixer.cs
+++ b/CyclopsDockingMod/Fixers/uGUI_MainMenuFixer.cs
@@ -40,7 +40,7 @@ namespace CyclopsDockingMod.Fixers
 			}
 			catch (Exception ex)
 			{
-				Logger.Log("ERROR: Exception caught while retrieving game info. Exception=[" + ex.ToString() + "]", Array.Empty<object>());
+				Logger.Error("Exception caught while retrieving game info. Exception=[" + ex.ToString() + "]", Array.Empty<object>());
 				gameInfo = null;
 			}
 			if (gameInfo != null)

--- a/CyclopsDockingMod/Logger.cs
+++ b/CyclopsDockingMod/Logger.cs
@@ -1,19 +1,48 @@
 ﻿using System;
-using System.Globalization;
+using BepInEx.Logging;
 
 namespace CyclopsDockingMod
 {
 	internal static class Logger
 	{
-		internal static void Log(string text, params object[] args)
+		internal static void Debug(string text, params object[] args)
 		{
-			string text2 = "[CyclopsDockingMod] " + ((args != null && args.Length != 0) ? string.Format(CultureInfo.InvariantCulture, text, args) : text);
+			Log(LogLevel.Debug, text, args);
+		}
+
+		internal static void Info(string text, params object[] args)
+		{
+			Log(LogLevel.Info, text, args);
+		}
+
+		internal static void Message(string text, params object[] args)
+		{
+			Log(LogLevel.Message, text, args);
+		}
+
+		internal static void Warning(string text, params object[] args)
+		{
+			Log(LogLevel.Warning, text, args);
+		}
+
+		internal static void Error(string text, params object[] args)
+		{
+			Log(LogLevel.Error, text, args);
+		}
+
+		internal static void Fatal(string text, params object[] args)
+		{
+			Log(LogLevel.Fatal, text, args);
+		}
+
+		internal static void Log(LogLevel level, string text, params object[] args)
+		{
+			if (args != null && args.Length > 0)
+				text = string.Format(text, args);
 			if (CyclopsDockingMod_EntryPoint._logger != null)
-			{
-				CyclopsDockingMod_EntryPoint._logger.LogMessage(text2);
-				return;
-			}
-			Console.WriteLine(text2);
+				CyclopsDockingMod_EntryPoint._logger.Log(level, text);
+			else
+				Console.WriteLine($"[CyclopsDockingMod] {level} {text}");
 		}
 	}
 }

--- a/CyclopsDockingMod/Routing/AutoPilot.cs
+++ b/CyclopsDockingMod/Routing/AutoPilot.cs
@@ -486,13 +486,13 @@ namespace CyclopsDockingMod.Routing
 			{
 				if (!Directory.Exists(saveFolderPath))
 				{
-					Logger.Log("INFO: No save directory found for Cyclops auto-pilot routes at \"" + saveFolderPath + "\".");
+					Logger.Info("No save directory found for Cyclops auto-pilot routes at \"" + saveFolderPath + "\".");
 					return;
 				}
 				string text = FilesHelper.Combine(saveFolderPath, "routes.txt");
 				if (File.Exists(text))
 				{
-					Logger.Log("INFO: Loading Cyclops auto-pilot routes from \"" + text + "\".");
+					Logger.Info("Loading Cyclops auto-pilot routes from \"" + text + "\".");
 					string[] array;
 					try
 					{
@@ -500,7 +500,7 @@ namespace CyclopsDockingMod.Routing
 					}
 					catch (Exception ex)
 					{
-						Logger.Log("ERROR: Exception caught while loading Cyclops auto-pilot routes. Exception=[" + ex.ToString() + "]");
+						Logger.Error("Exception caught while loading Cyclops auto-pilot routes. Exception=[" + ex.ToString() + "]");
 						return;
 					}
 					if (array != null && array.Length != 0)
@@ -513,14 +513,14 @@ namespace CyclopsDockingMod.Routing
 									AutoPilot.Routes.Add(route);
 							}
 					}
-					Logger.Log("INFO: Cyclops auto-pilot routes loaded. Player made {0} custom routes.", new object[] { AutoPilot.Routes.Count });
+					Logger.Info("Cyclops auto-pilot routes loaded. Player made {0} custom routes.", new object[] { AutoPilot.Routes.Count });
 					return;
 				}
-				Logger.Log("INFO: No Cyclops auto-pilot routes saved at \"" + text + "\".");
+				Logger.Info("No Cyclops auto-pilot routes saved at \"" + text + "\".");
 				return;
 			}
 			else
-				Logger.Log("INFO: Could not find save slot for Cyclops auto-pilot routes.");
+				Logger.Info("Could not find save slot for Cyclops auto-pilot routes.");
 		}
 
 		internal static void SaveRoutes()
@@ -535,7 +535,7 @@ namespace CyclopsDockingMod.Routing
 				string saveFolderPath = FilesHelper.GetSaveFolderPath();
 				if (saveFolderPath.Contains("/test/"))
 				{
-					Logger.Log("ERROR: Unable to find save folder path at [" + saveFolderPath + "].");
+					Logger.Error("Unable to find save folder path at [" + saveFolderPath + "].");
 					return;
 				}
 				if (!Directory.Exists(saveFolderPath))
@@ -546,16 +546,16 @@ namespace CyclopsDockingMod.Routing
 					}
 					catch (Exception ex)
 					{
-						Logger.Log($"ERROR: Exception caught while creating folder at [{saveFolderPath}]. Exception=[{ex.ToString()}]");
+						Logger.Error($"Exception caught while creating folder at [{saveFolderPath}]. Exception=[{ex.ToString()}]");
 					}
 				}
 				if (!Directory.Exists(saveFolderPath))
 				{
-					Logger.Log("ERROR: Unable to create save folder at [" + saveFolderPath + "].");
+					Logger.Error("Unable to create save folder at [" + saveFolderPath + "].");
 					return;
 				}
 				string text2 = FilesHelper.Combine(saveFolderPath, "routes.txt");
-				Logger.Log("INFO: Saving {0} Cyclops auto-pilot routes to \"{1}\".", new object[]
+				Logger.Info("Saving {0} Cyclops auto-pilot routes to \"{1}\".", new object[]
 				{
 					AutoPilot.Routes.Count,
 					text2
@@ -566,7 +566,7 @@ namespace CyclopsDockingMod.Routing
 				}
 				catch (Exception ex2)
 				{
-					Logger.Log($"ERROR: Exception caught while saving Cyclops auto-pilot routes at [{text2}]. Exception=[{ex2.ToString()}]");
+					Logger.Error($"Exception caught while saving Cyclops auto-pilot routes at [{text2}]. Exception=[{ex2.ToString()}]");
 				}
 			}
 		}

--- a/CyclopsDockingMod/Routing/Route.cs
+++ b/CyclopsDockingMod/Routing/Route.cs
@@ -107,9 +107,9 @@ namespace CyclopsDockingMod.Routing
 							num13 = array5.Length;
 					}
 					if (num13 > 5)
-						Logger.Log($"WARNING: Could not load Cyclops auto-pilot route. Serial=[{array[0]}/{array[1]}/{array[2]}/{array[3]}/{array[4]}/{array[5]}/{array[6]}/{array[7]}/{array[8]}/{array[9]}/...] NbPoints=[{num13}]");
+						Logger.Warning($"Could not load Cyclops auto-pilot route. Serial=[{array[0]}/{array[1]}/{array[2]}/{array[3]}/{array[4]}/{array[5]}/{array[6]}/{array[7]}/{array[8]}/{array[9]}/...] NbPoints=[{num13}]");
 					else
-						Logger.Log($"WARNING: Could not load Cyclops auto-pilot route. Serial=[{array[0]}/{array[1]}/{array[2]}/{array[3]}/{array[4]}/{array[5]}/{array[6]}/{array[7]}/{array[8]}/{array[9]}/{array[10]}]");
+						Logger.Warning($"Could not load Cyclops auto-pilot route. Serial=[{array[0]}/{array[1]}/{array[2]}/{array[3]}/{array[4]}/{array[5]}/{array[6]}/{array[7]}/{array[8]}/{array[9]}/{array[10]}]");
 				}
 			}
 			return null;


### PR DESCRIPTION
Non-destructive, code for SMLHelper version is intact and can be compiled by fixing the csproj file's subnautica directory, installing SMLHelper, and then using the DebugSML or ReleaseSML configurations.

note: may require installation of the Nautilus project templates.