### PR TITLE
Update for the latest Subnautica version

### DIFF
--- a/CyclopsDockingMod/BaseItem.cs
+++ b/CyclopsDockingMod/BaseItem.cs
@@ -20,11 +20,6 @@ namespace CyclopsDockingMod
         }
 
         [SetsRequiredMembers]
-        public BaseItem(string classID, string name, string desc, Atlas.Sprite icon) : this(PrefabInfo.WithTechType(classID, name, desc, unlockAtStart: true).WithFileName(DefaultResourcePath + classID).WithIcon(icon))
-        {
-        }
-
-        [SetsRequiredMembers]
         protected BaseItem(PrefabInfo info) : base(info)
         {
             SetGameObject(GetGameObject);

--- a/CyclopsDockingMod/CyclopsHatchConnector.cs
+++ b/CyclopsDockingMod/CyclopsHatchConnector.cs
@@ -7,8 +7,8 @@ using System.Diagnostics.CodeAnalysis;
 #else
 using SMLHelper.V2.Crafting;
 using SMLHelper.V2.Handlers;
-#endif
 using Ingredient = CraftData.Ingredient;
+#endif
 using UnityEngine;
 
 namespace CyclopsDockingMod
@@ -68,14 +68,17 @@ namespace CyclopsDockingMod
 			CyclopsDockingMod.CyclopsHatchConnector = base.TechType;
 			this.IsHabitatBuilder = true;
 #if SUBNAUTICA_NAUTI
-            base.Recipe = new RecipeData
+            base.Recipe = new RecipeData(this.SortIngredients())
+            {
+                craftAmount = 1
+            };
 #else
             base.Recipe = new TechData
-#endif
 			{
 				craftAmount = 1,
 				Ingredients = this.SortIngredients()
 			};
+#endif
 		}
 
 		private List<Ingredient> SortIngredients()

--- a/CyclopsDockingMod/Fixers/BuilderFixer.cs
+++ b/CyclopsDockingMod/Fixers/BuilderFixer.cs
@@ -114,14 +114,18 @@ namespace CyclopsDockingMod.Fixers
 				for (int i = 0; i < componentsInChildren.Length; i++)
 					UnityEngine.Object.Destroy(componentsInChildren[i]);
 				BuilderFixer._renderers.SetValue(null, MaterialExtensions.AssignMaterial((GameObject)BuilderFixer._ghostModel.GetValue(null), (Material)BuilderFixer._ghostStructureMaterial.GetValue(null), true));
-				string poweredPrefabName = CraftData.GetPoweredPrefabName((TechType)BuilderFixer._constructableTechType.GetValue(null));
-				if (!string.IsNullOrEmpty(poweredPrefabName))
+				var getPoweredPrefabName = typeof(CraftData).GetMethod("GetPoweredPrefabName", BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
+				if (getPoweredPrefabName != null)
 				{
-					CoroutineHost.StartCoroutine((IEnumerator)BuilderFixer._CreatePowerPreviewAsync.Invoke(null, new object[]
+					string poweredPrefabName = (string)getPoweredPrefabName.Invoke(null, new object[] { (TechType)BuilderFixer._constructableTechType.GetValue(null) });
+					if (!string.IsNullOrEmpty(poweredPrefabName))
 					{
-						(GameObject)BuilderFixer._ghostModel.GetValue(null),
-						poweredPrefabName
-					}));
+						CoroutineHost.StartCoroutine((IEnumerator)BuilderFixer._CreatePowerPreviewAsync.Invoke(null, new object[]
+						{
+							(GameObject)BuilderFixer._ghostModel.GetValue(null),
+							poweredPrefabName
+						}));
+					}
 				}
 				BuilderFixer._InitBounds.Invoke(null, new object[] { (GameObject)BuilderFixer._prefab.GetValue(null) });
 			}

--- a/CyclopsDockingMod/Fixers/MyuGUI_SignInputFixer.cs
+++ b/CyclopsDockingMod/Fixers/MyuGUI_SignInputFixer.cs
@@ -1,4 +1,5 @@
-﻿namespace CyclopsDockingMod.Fixers
+/*
+namespace CyclopsDockingMod.Fixers
 {
 	internal static class MyuGUI_SignInputFixer
 	{
@@ -9,3 +10,4 @@
 		}
 	}
 }
+*/

--- a/CyclopsDockingMod/RequiredMemberPolyfill.cs
+++ b/CyclopsDockingMod/RequiredMemberPolyfill.cs
@@ -1,0 +1,21 @@
+#if SUBNAUTICA_NAUTI
+namespace System.Runtime.CompilerServices
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+    internal sealed class RequiredMemberAttribute : Attribute { }
+
+    [AttributeUsage(AttributeTargets.All, AllowMultiple = true, Inherited = false)]
+    internal sealed class CompilerFeatureRequiredAttribute : Attribute
+    {
+        public CompilerFeatureRequiredAttribute(string featureName) { FeatureName = featureName; }
+        public string FeatureName { get; }
+        public bool IsOptional { get; set; }
+    }
+}
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
+    internal sealed class SetsRequiredMembersAttribute : Attribute { }
+}
+#endif


### PR DESCRIPTION
Provide compatibility fixes for SUBNAUTICA_NAUTI and other runtime differences:

- Add RequiredMemberPolyfill to define RequiredMember, CompilerFeatureRequired and SetsRequiredMembers attributes when building for SUBNAUTICA_NAUTI.
- Remove the obsolete BaseItem constructor that relied on SetsRequiredMembers.
- Update CyclopsHatchConnector recipe initialization: use RecipeData(...) constructor for SUBNAUTICA_NAUTI and set craftAmount inline to match API differences.
- Make BuilderFixer robust to API changes by reflecting CraftData.GetPoweredPrefabName and only invoking the power-preview coroutine when the method and resulting prefab name exist.
- Temporarily comment out MyuGUI_SignInputFixer.

These changes reduce compile/runtime errors across different game/SDK versions by polyfilling missing attributes and guarding calls against missing APIs.